### PR TITLE
Update packages.json to not exclude node v0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "keywords": ["version", "package", "json", "display", "number"],
   "main": "./lib/version",
   "engines":{
-    "node":">= 0.4.11 < 0.7.0"
+    "node":">= 0.4.11 < 0.9.0"
   },
   "dependencies": {
     "request":"2.2.5"


### PR DESCRIPTION
Tested under v0.7.12 which should be pretty much identical to the upcoming v0.8 and found no issues. Updated packages.json to allow all 0.7 and 0.8 versions so this can be pulled in as a dependency when running on those releases.
