### PR TITLE
Use http registry instead of https one

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -40,7 +40,7 @@ version.fetchNode = function(name, options, callback) {
   // external  
   } else {
     callback = callback || options;
-    request('https://registry.npmjs.org/' + name + '/latest', function(error, response, body) {
+    request('http://registry.npmjs.org/' + name + '/latest', function(error, response, body) {
       if (error) {
         callback(error, null);
       } else if (response.statusCode === 404) {


### PR DESCRIPTION
Now the tests pass. Looks like there's something weird going on with the https version of the registry as it gives `UNABLE_TO_VERIFY_LEAF_SIGNATURE` error. I fixed this simply by using the http version of the registry. It should be enough for this sort of purpose.
