### PR TITLE
use try-catch for JSON.parse

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -26,12 +26,18 @@ exports.fetch = function(name, options, callback) {
       if (error) {
         callback(error, null);
       } else {
-        var pkg = JSON.parse(data);
+        var pkg;
+        try {
+          pkg = JSON.parse(data);
+        }
+        catch (error) {
+          return callback(error, null);
+        }
         var _version = pkg['version'];
         callback(null, _version);
       }
     });
-  // external  
+  // external
   } else {
     callback = callback || options;
     request('http://registry.npmjs.org/' + name + '/latest', function(error, response, body) {


### PR DESCRIPTION
**Problem**
It throws an exception in case of malformed `package.json`.

**Solution**
Wrap `JSON.parse()` into try-catch block.
