### PR TITLE
update dependencies to fix security warning on npm audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,29 +3,46 @@
   "author": "Edward Hotchkiss <edwardhotchkiss@me.com>",
   "description": "NodeJS package.json version number fetcher",
   "version": "0.1.2",
-  "contributors":[
-    { "name": "Edward Hotchkiss", "email": "edwardhotchkiss@me.com" },
-    { "name": "Jamie Nguyen", "github": "https://github.com/jamielinux" },
-    { "name": "Juho Vepsäläinen", "github" : "https://github.com/bebraw" }
+  "contributors": [
+    {
+      "name": "Edward Hotchkiss",
+      "email": "edwardhotchkiss@me.com"
+    },
+    {
+      "name": "Jamie Nguyen",
+      "github": "https://github.com/jamielinux"
+    },
+    {
+      "name": "Juho Vepsäläinen",
+      "github": "https://github.com/bebraw"
+    }
   ],
   "repository": {
     "type": "git",
     "url": "git://github.com/edwardhotchkiss/version.git"
   },
-  "keywords": ["version", "package", "json", "display", "number"],
+  "keywords": [
+    "version",
+    "package",
+    "json",
+    "display",
+    "number"
+  ],
   "main": "./lib/version",
-  "engines":{
-    "node":">= 0.8.0"
+  "engines": {
+    "node": ">= 0.8.0"
   },
-  "licenses":[{
-    "type":"MIT",
-    "url":"http://github.com/edwardhotchkiss/short/LICENSE"
-  }],
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://github.com/edwardhotchkiss/short/LICENSE"
+    }
+  ],
   "dependencies": {
-    "request":"2.12.0"
+    "request": "^2.88.2"
   },
-  "devDependencies":{
-    "vows":"0.7.0"
+  "devDependencies": {
+    "vows": "^0.8.3"
   },
   "scripts": {
     "test": "vows test/*.test.js --spec"


### PR DESCRIPTION
Tests are still passing:

```
 npm run test

> version@0.1.2 test
> vows test/*.test.js --spec

 
  ♢ General Module Tests 
  
  when instantiating version
    ✓ version should be an object and version.fetch and should be a function
  when fetching this packages version without any other formal parameters
    ✓ we should receive no error back and receive a version in string format
  
  ♢ Testing version.fetch() on: underscore 
  
  When fetching the Version number
    ✓ we should receive no error back and receive a version in string format
  
  ♢ Testing version.fetch() on: coffee-script 
  
  When fetching the Version number
    ✓ we should receive no error back and receive a version in string format
  
  ♢ Testing version.fetch() on: request 
  
  When fetching the Version number
    ✓ we should receive no error back and receive a version in string format
  
  ♢ Testing version.fetch() on: optimist 
  
  When fetching the Version number
    ✓ we should receive no error back and receive a version in string format
  
  ♢ Testing version.fetch() on: connect 
  
  When fetching the Version number
    ✓ we should receive no error back and receive a version in string format
  
  ♢ Testing version.fetch() on: colors 
  
  When fetching the Version number
    ✓ we should receive no error back and receive a version in string format
  
  ♢ Testing version.fetch() on: async 
  
  When fetching the Version number
    ✓ we should receive no error back and receive a version in string format
  
  ♢ Testing version.fetch() on: uglify-js 
  
  When fetching the Version number
    ✓ we should receive no error back and receive a version in string format
  
  ♢ Testing version.fetch() on: socket.io 
  
  When fetching the Version number
    ✓ we should receive no error back and receive a version in string format
  
  ♢ Testing version.fetch() on: redis 
  
  When fetching the Version number
    ✓ we should receive no error back and receive a version in string format
  
  ♢ Testing version.fetch() on: jade 
  
  When fetching the Version number
    ✓ we should receive no error back and receive a version in string format
  
  ♢ Testing version.fetch() on: jsdom 
  
  When fetching the Version number
    ✓ we should receive no error back and receive a version in string format
  
  ♢ Testing version.fetch() on: mime 
  
  When fetching the Version number
    ✓ we should receive no error back and receive a version in string format
  
  ♢ Testing version.fetch() on: vows 
  
  When fetching the Version number
    ✓ we should receive no error back and receive a version in string format
  
  ♢ Testing version.fetch() on: commander 
  
  When fetching the Version number
    ✓ we should receive no error back and receive a version in string format
  
  ♢ Testing version.fetch() on: mongodb 
  
  When fetching the Version number
    ✓ we should receive no error back and receive a version in string format
  
  ♢ Testing version.fetch() on: ejs 
  
  When fetching the Version number
    ✓ we should receive no error back and receive a version in string format
  
  ♢ Testing version.fetch() on: node-uuid 
  
  When fetching the Version number
    ✓ we should receive no error back and receive a version in string format
  
  ♢ Testing version.fetch() on: stylus 
  
  When fetching the Version number
    ✓ we should receive no error back and receive a version in string format
  
  ♢ Testing version.fetch() on: mongoose 
  
  When fetching the Version number
    ✓ we should receive no error back and receive a version in string format
  
  ♢ Self package.json Fetching 
  
  when fetching this packages version with no parameters but a callback
    ✓ we should receive no error back and receive a version in string format
 
✓ OK » 23 honored (11.485s) 
```